### PR TITLE
Migrate game rendering from Canvas 2D to Phaser 3

### DIFF
--- a/packages/web/src/game/GameCanvas.tsx
+++ b/packages/web/src/game/GameCanvas.tsx
@@ -57,6 +57,14 @@ export function GameCanvas({
       const scene = new GameScene();
       sceneRef.current = scene;
 
+      // Set up callback before the scene is created
+      scene.setOnReady(() => {
+        if (destroyed) return;
+        scene.setOnAgentClick((id) => onAgentClickRef.current?.(id));
+        readyRef.current = true;
+        syncToScene();
+      });
+
       const game = new Phaser.Game({
         type: Phaser.CANVAS,
         width: CANVAS_SIZE,
@@ -74,14 +82,6 @@ export function GameCanvas({
         banner: false,
       });
       gameRef.current = game;
-
-      // Once the scene finishes create(), wire the callback and push initial data.
-      scene.events.on("create", () => {
-        if (destroyed) return;
-        scene.setOnAgentClick((id) => onAgentClickRef.current?.(id));
-        readyRef.current = true;
-        syncToScene();
-      });
     });
 
     return () => {

--- a/packages/web/src/game/scenes/GameScene.ts
+++ b/packages/web/src/game/scenes/GameScene.ts
@@ -32,9 +32,14 @@ export class GameScene extends Phaser.Scene {
   private selectedAgentId: number | null = null;
   private shrinkBorder: number = GRID_SIZE;
   private onAgentClick?: (agentId: number) => void;
+  private onReady?: () => void;
 
   constructor() {
     super({ key: "GameScene" });
+  }
+
+  setOnReady(callback: () => void): void {
+    this.onReady = callback;
   }
 
   create(): void {
@@ -50,6 +55,9 @@ export class GameScene extends Phaser.Scene {
     this.input.on("pointerdown", (pointer: Phaser.Input.Pointer) => {
       this.handleClick(pointer.x, pointer.y);
     });
+
+    // Notify the React component that the scene is ready
+    this.onReady?.();
   }
 
   setOnAgentClick(callback: (agentId: number) => void): void {


### PR DESCRIPTION
Replace the raw Canvas 2D requestAnimationFrame loop with a proper
Phaser game instance managed through a React bridge component.

- Add GameScene (Phaser.Scene) with layered Graphics rendering:
  grid, zone overlay, items, alliance lines, agents with HP bars
- Rewrite GameCanvas as a React↔Phaser bridge using dynamic imports
  to avoid Next.js SSR issues
- Keep GameCanvasProps interface unchanged so page.tsx is unaffected
- Use Phaser Scale.FIT for responsive sizing within the container

https://claude.ai/code/session_01StuAkgxHCRx4hfzKHKJtZx